### PR TITLE
Change the 2022 to 2023 in source line

### DIFF
--- a/components/global/PrintFooter.vue
+++ b/components/global/PrintFooter.vue
@@ -4,7 +4,7 @@
       <img class="object-contain h-8 mr-4 filter-gray" src="/icon-nmhc.png" alt="NMHC Logo"><img class="object-contain h-8 filter-gray" src="/icon-naa.png" alt="NAA Logo">
     </div>
     <div class="text-xs">
-      Source: Hoyt Advisory Services; NMHC/NAA; 2022 American Community Survey, U.S. Census Bureau
+      Source: Hoyt Advisory Services; NMHC/NAA; 2023 American Community Survey, U.S. Census Bureau
     </div>
   </div>
 </template>

--- a/components/global/SourceLine.vue
+++ b/components/global/SourceLine.vue
@@ -5,7 +5,7 @@
       <a href="https://www.nmhc.org/" target="_new">NMHC</a>
       <span>/</span>
       <a href="http://www.naahq.org/" target="_new">NAA</a>;
-      <a href="https://www.census.gov/programs-surveys/acs/" target="_new">2022 American Community Survey, U.S. Census Bureau</a>
+      <a href="https://www.census.gov/programs-surveys/acs/" target="_new">2023 American Community Survey, U.S. Census Bureau</a>
     </div>
   </div>
 </template>


### PR DESCRIPTION
On the bottom of each page, there's a source line that says "Hoyt Advisory Services; NMHC / NAA; 2022 American Community Survey, U.S. Census Bureau". Please change the 2022 to 2023